### PR TITLE
fix: Added svgo as default plugin as long svgo is not false

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "homepage": "https://github.com/kazijawad/esbuild-plugin-svgr#readme",
     "dependencies": {
         "@svgr/core": "^8.0.0",
-        "@svgr/plugin-jsx": "^8.0.1"
+        "@svgr/plugin-jsx": "^8.0.1",
+        "@svgr/plugin-svgo": "^8.0.0"
     },
     "devDependencies": {
         "esbuild": "^0.19.1"

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,15 @@ const svgrPlugin = (options = {}) => ({
                 options.plugins = ['@svgr/plugin-jsx']
             }
 
+            if(options.svgo !== false) {
+                options.svgo = true;
+                if (options.plugins && !options.plugins.includes('@svgr/plugin-svgo')) {
+                    options.plugins = ['@svgr/plugin-svgo', ...options.plugins || []]
+                } else if (!options.plugins) {
+                    options.plugins = ['@svgr/plugin-svgo']
+                }
+            }
+
             const contents = await transform(svg, { ...options }, { filePath: args.path })
 
             if (args.suffix === '?url') {


### PR DESCRIPTION
First of all, thank you for creating this plugin.
I came to esbuild-plugin-svgr from @svgr/rollup and was happy that there allready exists an equivalent to the rollup version.

Unfortunately, I had the issue that esbuild-plugin-svgr does not behave like the official @svgr/rollup.
A lot of my SVGs looked wrong. This happened because the CSS classes of the SVGs clashed, and the styles got overwritten. I figured out that esbuild-plugin-svgr does not invoke the @svgr/plugin-svgo by default as the rollup plugin does. The svgo plugin would make the classes and IDs unique so that clashes can not happen.

Adding @svgr/plugin-svgo to the options in the esbuild config file is possible. But I think it would save a lot of work for people if the esbuild-plugin-svgr would behave the same as the official @svgr/rollup. 

Here, you see that svgo should be true by default:
[https://react-svgr.com/docs/options/#svgo](https://react-svgr.com/docs/options/#svgo)

Here you see that the official @svgr/rollup plugin also has svgo set as default plugin:
[https://github.com/gregberge/svgr/blob/main/packages/rollup/src/index.ts#L63](https://github.com/gregberge/svgr/blob/main/packages/rollup/src/index.ts#L63)

The svgo plugin needs to be before the jsx plugin. Therefore, I added it the way as you can see in the code.
