### PR TITLE
add option not to mark external so svgs can be processed directly (resolves #14)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 const { readFile } = require('node:fs/promises')
 const { transform } = require('@svgr/core')
 
-const svgrPlugin = (options = {}) => ({
+const svgrPlugin = (options = {
+    markExternal: true
+}) => ({
     name: 'svgr',
     setup(build) {
         build.onResolve({ filter: /\.svg$/ }, async (args) => {
@@ -12,8 +14,10 @@ const svgrPlugin = (options = {}) => ({
                 case 'require-resolve':
                     return
                 default:
-                    return {
-                        external: true,
+                    if (options.markExternal) {
+                        return {
+                            external: true,
+                        }
                     }
             }
         })


### PR DESCRIPTION
A little context:
I've been using this plugin for a while to directly convert an array of paths to SVGs

```ts
const svgs = await globby(resolve(SRC_DIR, './**/*.svg'));

await esbuild.build({
    entryPoints: svgs,
    bundle: false,
    outdir: resolve(BIN_DIR, 'svg/raw'),
    outExtension: {
    	'.js': '.svg.js'
     },
     outbase: SRC_DIR,
     format: 'esm',
     plugins: [
         svgrPlugin({ markExternal: false })
     ]
});

```
This worked great until I got this error:

```
✘ [ERROR] The entry point "/project-dir/src/GroupHeader/chevron-down-icon.svg" cannot be marked as external
✘ [ERROR] The entry point "/project-dir/src/GroupHeader/chevron-up-icon.svg" cannot be marked as external
✘ [ERROR] The entry point "/project-dir/src/Popover/PopoverCloseButton/close-icon.svg" cannot be marked as external
```

After a bit of digging, I found #14 where someone was getting the same error. After a bit more digging, I found the culprit:
https://github.com/kazijawad/esbuild-plugin-svgr/blob/0765cd25fdcba5c9e4f034cf069dc6b1ca09e2fa/src/index.js#L14-L18

I've added a parameter that can be passed to the plugin constructor which when false does not mark the resource as external.
```ts
await esbuild.build({
    // ...
     plugins: [
         svgrPlugin({ markExternal: false })
     ]
});
```
This way I don't have to maintain some "index file" that imports each and every SVGs. My use case is pretty specific, but at least one person had the same issue so I'm submitting this PR.

In the meantime, I've forked and published a (scoped) version of this package with my edit so anyone can use until the PR is merged or if the maintainer declines to do so.
```sh
npm install -D @patrick-lienau/esbuild-plugin-svgr
```
or
```sh
yarn add -D @patrick-lienau/esbuild-plugin-svgr
```
and of course replace `esbuild-plugin-svgr` with `@patrick-lienau/esbuild-plugin-svgr` anywhere you import the plugin in JS or as a string in whatever config file you have.

@kazijawad thanks for your time, I know maintaining packages can be tedious, let me know if there's anything I can do to help.

